### PR TITLE
Add more tasks to dobi.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .dobi
+swagger.json

--- a/Dockerfile.swagger-tools
+++ b/Dockerfile.swagger-tools
@@ -1,2 +1,0 @@
-FROM node
-RUN npm install -g swagger-tools

--- a/Dockerfile.yamllint
+++ b/Dockerfile.yamllint
@@ -1,2 +1,0 @@
-FROM python
-RUN pip install yamllint

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: validate
 validate:
-	docker build -t docker-api-reference-yamllint -f Dockerfile.yamllint .
-	docker run -v `pwd`:/code -w /code docker-api-reference-yamllint yamllint swagger.yaml
-	docker build -t docker-api-reference-swagger-tools -f Dockerfile.swagger-tools .
-	docker run -v `pwd`:/code -w /code docker-api-reference-swagger-tools swagger-tools validate swagger.yaml
+	docker build -t docker-api-reference-yamllint -f dockerfiles/Dockerfile.yamllint dockerfiles/
+	docker run -v `pwd`:/code docker-api-reference-yamllint swagger.yaml
+	docker build -t docker-api-reference-swagger-tools -f dockerfiles/Dockerfile.swagger-tools dockerfiles/
+	docker run -v `pwd`:/code docker-api-reference-swagger-tools swagger.yaml
 
 swagger.json: swagger.yaml validate
 	python -c 'import sys, yaml, json; json.dump(yaml.load(sys.stdin), sys.stdout, indent=4)' < swagger.yaml > swagger.json

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -39,5 +39,14 @@ job=swagger.json:
     artifact: "swagger.json"
 
 
+compose=serve-index:
+    files: [docker-compose.yml]
+    project: '{project}'
+
+
 alias=validate:
     tasks: [yaml-lint, swagger-validate]
+
+
+alias=preview:
+    tasks: ['serve-index:attach']

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -7,12 +7,37 @@ mount=source:
     bind: .
     path: /code
 
-image=validator:
-    image: swagger-validator
-    context: dockerfiles
-    dockerfile: Dockerfile.validate
 
-job=validate:
-    use: validator
+image=spec-validator:
+    image: swagger-spec-validator
+    context: dockerfiles/
+    dockerfile: Dockerfile.swagger-tools
+
+image=linter:
+    image: yaml-linter
+    context: dockerfiles/
+    dockerfile: Dockerfile.yamllint
+
+
+job=swagger-validate:
+    use: spec-validator
     mounts: [source]
+    command: "swagger.yaml"
 
+job=yaml-lint:
+    use: linter
+    mounts: [source]
+    command: "swagger.yaml"
+
+job=swagger.json:
+    use: linter
+    mounts: [source]
+    entrypoint: "sh -c '
+        python -c \"import sys, yaml, json;
+            json.dump(yaml.load(sys.stdin), sys.stdout, indent=4)\"
+        < swagger.yaml > swagger.json'"
+    artifact: "swagger.json"
+
+
+alias=validate:
+    tasks: [yaml-lint, swagger-validate]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 nginx:
-  image: nginx
+  image: nginx:1.11-alpine
   volumes:
    - "./:/usr/share/nginx/html"
   ports:

--- a/dockerfiles/Dockerfile.swagger-tools
+++ b/dockerfiles/Dockerfile.swagger-tools
@@ -3,4 +3,4 @@ FROM    node:0.10
 RUN     npm install -g swagger-tools
 
 WORKDIR /code
-ENTRYPOINT ["swagger-tools", "validate", "swagger.yaml"]
+ENTRYPOINT ["swagger-tools", "validate"]

--- a/dockerfiles/Dockerfile.yamllint
+++ b/dockerfiles/Dockerfile.yamllint
@@ -1,0 +1,6 @@
+
+FROM    python:3.5-alpine
+RUN     pip install yamllint
+
+WORKDIR /code
+ENTRYPOINT ["yamllint"]


### PR DESCRIPTION
Adds the `yaml-lint`,  `swagger-json`, and `preview` tasks

You can see a few differences between dobi and make by running:
```
make validate
dobi validate
```

After the first dobi run, the `docker build` will be cached, so you don't get the build output clutter in stdout.

`dobi preview` will run the `docker-compose` to preview the docs